### PR TITLE
Security: GitHub Actions pinnen op volledige commit-SHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
   get-versions:
     runs-on: [self-hosted]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
@@ -114,10 +114,10 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Create tags
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const version = "${{ needs.get-versions.outputs.terraform_version }}";
@@ -147,10 +147,10 @@ jobs:
       matrix:
         docker: ${{ fromJSON(needs.get-versions.outputs.docker_build_matrix) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Login to AWS
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           aws-region: ${{ secrets.AWS_REGION }}
           role-to-assume: ${{ secrets.AWS_ROLE }}
@@ -164,10 +164,10 @@ jobs:
             | docker login --username AWS --password-stdin ${{ secrets.ECR_REPO }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
         with:
           cache-binary: false
           platforms: linux/amd64,linux/arm64
@@ -179,7 +179,7 @@ jobs:
       #            image=moby/buildkit:buildx-stable-1
 
       - name: Cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         id: cache
         with:
           path: |
@@ -190,7 +190,7 @@ jobs:
             cache-docker-${{ matrix.docker.component }}
 
       - name: inject cache into docker
-        uses: reproducible-containers/buildkit-cache-dance@v3.1.0
+        uses: reproducible-containers/buildkit-cache-dance@5de31fc1534ed8789e63d41ea933c5df9944a261 # v3.1.0
         with:
           cache-map: |
             {
@@ -239,7 +239,7 @@ jobs:
             --set="${COMPONENT}.cache-to=type=registry,ref=${DOCKER_REPO}/inbo-vbp-${COMPONENT}:${CACHE_TAG},oci-mediatypes=true,image-manifest=true,mode=max"
 
       - name: Create tags
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             github.rest.git.createRef({
@@ -254,11 +254,11 @@ jobs:
     needs: get-versions
     if: needs.get-versions.outputs.frontend_version != ''
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 23
           cache: "npm"
@@ -276,14 +276,14 @@ jobs:
           tar -cvzf frontend-${{ needs.get-versions.outputs.frontend_version }}.tar.gz -C "$(pwd)/dist" ./
 
       - name: Archive failed test report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: failure()
         with:
           name: frontend-tests
           path: ./test-output.json
 
       - name: Create release
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1
         with:
           commit: ${{ github.sha }}
           tag: frontend-v${{ needs.get-versions.outputs.frontend_version }}
@@ -301,11 +301,11 @@ jobs:
       matrix:
         lambda: ${{ fromJSON(needs.get-versions.outputs.lambda_build_matrix) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: "npm"
@@ -322,7 +322,7 @@ jobs:
           mv function.zip ${{ matrix.lambda.name }}-${{ matrix.lambda.version }}.zip
 
       - name: Create release
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1
         with:
           commit: ${{ github.sha }}
           tag: lambda-${{ matrix.lambda.name }}-v${{ matrix.lambda.version }}
@@ -347,7 +347,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout terraform repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: "inbo/inbo-aws-biodiversiteitsportaal-terraform"
           token: ${{ secrets.GIT_PAT_TOKEN }}
@@ -383,7 +383,7 @@ jobs:
           fi
 
       - name: Create Pull Request
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         if: steps.update-versions.outputs.changes == 'true'
         with:
           github-token: ${{ secrets.GIT_PAT_TOKEN }}


### PR DESCRIPTION
_Onderdeel van een INBO-brede security-hardening: SHA-pinning van GitHub Actions. Aanbevolen door o.a. [GitHub Security Hardening](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)._